### PR TITLE
fixed payload length for sm living dex

### DIFF
--- a/PKSMScript/scripts.bat
+++ b/PKSMScript/scripts.bat
@@ -77,7 +77,7 @@
 @py -3 PKSMScript.py "Save language to CHT" -i 0x1235 1 0xA 1
 @py -3 PKSMScript.py "Clear Mystery Gift data" -i 0x65C00 1 0x0 12928
 @py -3 PKSMScript.py "Set max money" -i 0x4000 4 9999999 1
-@py -3 PKSMScript.py "Inject living dex" -i 0x4E00 186992 "data/living7.bin" 1
+@py -3 PKSMScript.py "Inject living dex" -i 0x4E00 186064 "data/living7.bin" 1
 @py -3 PKSMScript.py "Set max Battle Points" -i 0x0411C 4 9999 1
 @py -3 PKSMScript.py "Set max Festival Coins" -i 0x50D08 4 9999999 1
 @py -3 PKSMScript.py "Set max Camera Shots" -i 0x65004 4 9999999 1


### PR DESCRIPTION
Currently injecting the living dex into SM gives the 4 USUM pkm at the end of the dex. Each pkm is 232 bytes, so this ignores the last 928 bytes when reading living7 during the creation of the .pksm file.